### PR TITLE
マイページ(本人情報)_画像表示

### DIFF
--- a/app/assets/stylesheets/modules/_mypage.scss
+++ b/app/assets/stylesheets/modules/_mypage.scss
@@ -63,6 +63,12 @@
 
             &--value {
               width: 450px;
+
+              .avatar__show {
+                width: 100px;
+                height: 100px;
+                border: 1px solid $fontColorGray;
+              }
             }
           }
         }

--- a/app/views/users/mypage.html.haml
+++ b/app/views/users/mypage.html.haml
@@ -50,10 +50,10 @@
           %li.info__list
             .info__list--label アバター
             .info__list--value
-            -# - if @user.avatar.present?
-            -#   = image_tag(@user.avatar_path)
-            -# - else
-            -#   = image_tag "no_image.png"
+              - if @user.avatar.url.present?
+                = image_tag @user.avatar.url, class: "avatar__show"
+              - else
+                = image_tag "no_image.png", class: "avatar__show"
           %li.info__list
             .info__list--label プロフィール
             .info__list--value


### PR DESCRIPTION
## What
マイページ(本人情報)_画像表示を実装する。
登録がない場合はデフォルトでno_image画像を埋め込む。
## Why
ユーザーが登録したアバターを表示できるようにする為。