### PR TITLE
スタイリストのみ管理者ページへアクセスできるようbefore_actionを設定する

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,6 +1,7 @@
 class ShopsController < ApplicationController
   skip_before_action :authenticate_user!, only: :show
   before_action      :set_shop, only: [:show, :edit, :admin, :update, :destroy, :leave]
+  before_action      :set_admin_stylist, only: [:edit, :update, :leave, :destroy, :admin]
 
   def new
     @shop = Shop.new
@@ -22,12 +23,6 @@ class ShopsController < ApplicationController
   end
 
   def edit
-    # @shop.users.each do |admin_user|
-    #   if user_signed_in? && admin_user == current_user
-    #   else
-    #     render :show
-    #   end
-    # end
   end
 
   def update
@@ -39,23 +34,14 @@ class ShopsController < ApplicationController
   end
 
   def destroy 
-    @shop.users.each do |admin_user|
-      if user_signed_in? && admin_user == current_user
-        @shop.destroy
-        redirect_to root_path
-      else
-        redirect_to root_path
-      end
+    if @shop.destroy
+      redirect_to root_path
+    else
+      render :admin
     end
   end
 
   def admin
-    # @shop.users.each do |admin_user|
-    #   if user_signed_in? && admin_user == current_user
-    #   else
-    #     render :show
-    #   end
-    # end
   end
 
   def leave
@@ -69,5 +55,11 @@ class ShopsController < ApplicationController
 
   def set_shop
     @shop = Shop.find(params[:id])
+  end
+
+  def set_admin_stylist
+    unless @shop.users.include?(current_user)
+      redirect_to root_path
+    end
   end
 end

--- a/app/views/shops/show.html.haml
+++ b/app/views/shops/show.html.haml
@@ -9,10 +9,9 @@
           = link_to "商品一覧", shop_path(@shop.id), class: "menu__title"
         .container__left--menu
           = link_to "スタイリスト一覧", "#", class: "menu__title"
-        -  @shop.users.each do |admin_user|
-          - if user_signed_in? && admin_user == current_user
-            .container__left--menu
-              = link_to "管理者専用ページ", admin_shop_path, class: "menu__title"
+        - if @shop.users.include?(current_user)
+          .container__left--menu
+            = link_to "管理者専用ページ", admin_shop_path, class: "menu__title"
         .container__left--menu
           = link_to "カテゴリーから探す", "#", class: "menu__title"
         .container__left--menu


### PR DESCRIPTION
## What
スタイリストのみ管理者ページへアクセスできるようbefore_actionを設定する。
## Why
ショップ情報の編集や退会手続きなどはアクセス権限を付与する必要がある為。