### PR TITLE
shop登録後にスタイリストも登録可否のモデル単体テスト

### DIFF
--- a/spec/factories/shops.rb
+++ b/spec/factories/shops.rb
@@ -8,5 +8,11 @@ FactoryBot.define do
     address      {"北区1-1-1"}
     apartment    {"丸ビル101"}
     phone_number {"0611111111"}
+
+    trait :stylist do
+      after(:build) do |shop|
+        shop.users << build(:user)
+      end
+    end
   end
 end

--- a/spec/factories/stylists.rb
+++ b/spec/factories/stylists.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :stylist do
-    
+    shop
+    user
   end
 end

--- a/spec/models/shop_spec.rb
+++ b/spec/models/shop_spec.rb
@@ -64,5 +64,9 @@ RSpec.describe Shop, type: :model do
       shop.valid?
       expect(shop.errors[:phone_number]).to include("は不正な値です")
     end
+    it "全て入力されていればstylistの登録もOK" do
+      shop = create(:shop, :stylist)
+      expect(shop).to be_valid
+    end
   end
 end


### PR DESCRIPTION
## What
shop登録後にスタイリストも登録可否のモデル単体テストを行う。
## Why
shop登録後に自動的にstylistも登録される為、モデルにテストを追記する。