### PR TITLE
itemモデルにstockカラムを追加する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -63,7 +63,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :price, :explain, :size, :postage, :shipping_date, :gender, :shop_id, :category_id, brand_attributes: [:brand], images_attributes: [:item_image, :_destroy, :id]).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :price, :explain, :size, :postage, :shipping_date, :gender, :stock, :shop_id, :category_id, brand_attributes: [:brand], images_attributes: [:item_image, :_destroy, :id]).merge(user_id: current_user.id)
   end
 
   def set_item

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,6 +10,7 @@ class Item < ApplicationRecord
 
   validates :name, :explain, :size, :postage, :shipping_date, :gender, presence: true
   validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 100, less_than_or_equal_to: 9999999}
+  validates :stock, presence: true, presence: true, length: { in: 1..3 }, format: { with: /\A[0-9]+\z/ }
 
   enum size: { "XXS以下": 1, "XS(SS)": 2, "S": 3, "M": 4, "L": 5, "XL(LL)": 6, "2XL(3L)": 7, "3XL(4L)": 8, "4XL(5L)以上": 9, "FREESIZE": 10 }
   enum postage: { "送料無料": 1, "送料500円": 2, "送料1,000円": 3 }

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -71,6 +71,10 @@
           = f.label :gender, "性別タイプ", class: "label__text"
           %span.required__item 必須
           = f.select :gender, Item.genders.keys, {}, {class: "text__field--half"}
+        .field
+          = f.label :stock, "在庫数", class: "label__text"
+          %span.required__item 必須
+          = f.number_field :stock, min: 1, max: 300, class: "text__field--half"
         .field__hidden
           = f.hidden_field :shop_id, value: params[:shop_id]
 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -63,6 +63,10 @@
           = f.label :gender, "性別タイプ", class: "label__text"
           %span.required__item 必須
           = f.select :gender, Item.genders.keys, {}, {class: "text__field--half"}
+        .field
+          = f.label :stock, "在庫数", class: "label__text"
+          %span.required__item 必須
+          = f.number_field :stock, min: 1, max: 300, class: "text__field--half"
         .field__hidden
           = f.hidden_field :shop_id, value: params[:shop_id]
 

--- a/db/migrate/20200630114358_create_items.rb
+++ b/db/migrate/20200630114358_create_items.rb
@@ -8,6 +8,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.integer    :postage,       null: false, default: 1
       t.integer    :shipping_date, null: false, default: 1
       t.integer    :gender,        null: false, default: 1
+      t.integer    :stock,         null: false, default: 1
       t.references :user,          null: false, foreign_key: true
       t.references :shop,          null: false, foreign_key: true
       t.references :brand,         null: false, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2020_07_05_091746) do
     t.integer "postage", default: 1, null: false
     t.integer "shipping_date", default: 1, null: false
     t.integer "gender", default: 1, null: false
+    t.integer "stock", default: 1, null: false
     t.bigint "user_id", null: false
     t.bigint "shop_id", null: false
     t.bigint "brand_id", null: false


### PR DESCRIPTION
## What
itemモデルにstockカラムを追加する。
## Why
在庫数を管理し、商品購入機能と連携させる為。