### PR TITLE
未ログインユーザーの商品閲覧_改修

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -39,7 +39,6 @@
                   = f.label :purchase_amount, "購入数", class: "label__text"
                   = f.number_field :purchase_amount, min: 1, max: 5, class: "number-field"
                   %span.space-word 個
-                  = f.hidden_field :user_id, value: current_user.id
                   %script.payjp-button{"data-key": "pk_test_7909da3d557868a5ca4eddd3", src: "https://checkout.pay.jp", type: "text/javascript", "data-text": "今すぐ購入する", class: "input-btn"}
               .nav__btn--cart
                 .nav__btn--cart-text


### PR DESCRIPTION
## What
未ログインユーザーの商品閲覧の改修。
カート機能の不必要なcurrent_user.id取得があった為、削除する。
## Why
エラーが表示され、閲覧できなかった為。